### PR TITLE
Display range edits

### DIFF
--- a/dirigo/plugins/acquisitions.py
+++ b/dirigo/plugins/acquisitions.py
@@ -179,7 +179,7 @@ class LineAcquisition(Acquisition):
                 digi.acquire.buffers_acquired < self.spec.buffers_per_acquisition:
                 print(f"Acquired {digi.acquire.buffers_acquired} of {self.spec.buffers_per_acquisition}")
                 buffer = digi.acquire.get_next_completed_buffer()
-                if hasattr(self.hw, 'stage'):
+                if self.hw.stage or self.hw.objective_scanner:
                     buffer.positions = self.read_positions()
                 self.publish(buffer)
 

--- a/dirigo/plugins/processors.py
+++ b/dirigo/plugins/processors.py
@@ -15,9 +15,14 @@ TWO_PI = 2 * np.pi
 
 # issues:
 # need to support uint16 and uint8 (rarer)
-sig = (types.uint16[:,:,:], types.uint16[:,:,:], types.int32[:,:], types.int32[:,:])
-@njit(sig, parallel=True, fastmath=True, nogil=True, cache=True)
+sigs = [
+    #buffer_data          scaling_factor  resampled            start_indices     nsamples_to_sum
+    (types.int16[:,:,:],  types.int32,    types.int16[:,:,:],  types.int32[:,:], types.int32[:,:]),
+    (types.uint16[:,:,:], types.int32,    types.uint16[:,:,:], types.int32[:,:], types.int32[:,:])
+]
+@njit(sigs, parallel=True, fastmath=True, nogil=True, cache=True)
 def resample_kernel(buffer_data: np.ndarray, 
+                    scaling_factor: int,
                     resampled: np.ndarray, 
                     start_indices: np.ndarray, 
                     nsamples_to_sum: np.ndarray) -> np.ndarray:
@@ -65,7 +70,7 @@ def resample_kernel(buffer_data: np.ndarray,
             # resampled[si, fi, 1] = tmp1 // Nsum
             # Store the average back into resampled
             for c in range(Nchannels):
-                resampled[si, fi, c] = tmp_values[c] // Nsum
+                resampled[si, fi, c] = (scaling_factor * tmp_values[c]) // Nsum
 
     return resampled
 
@@ -129,8 +134,22 @@ def compute_cross_power_spectrum(F: np.ndarray):
 
 
 class RasterFrameProcessor(Processor):
-    def __init__(self, acquisition):
+    def __init__(self, 
+                 acquisition,
+                 bits_precision: int = 16):
+        """
+        Initialize a raster frame processor worker for the Acquisition worker.
+
+        To change default behavior of computing average for each pixel in 16-
+        bit precision, change the bits_precision argument.
+        """
         super().__init__(acquisition)
+
+        if (not isinstance(bits_precision, int)) or (bits_precision % 2) or not (8 <= bits_precision <= 16):
+            raise ValueError("Bits precision must be even integer between 8 and 16")
+        elif bits_precision < self._acq.data_acquisition_device.bit_depth:
+            raise ValueError("Bit precision can't be less than the data acquisition device bit depth.")
+        self._bits_precision = bits_precision
         
         self._spec: FrameAcquisitionSpec # to refine type hinting
         self.processed_shape = ( # Final shape after processing
@@ -143,13 +162,19 @@ class RasterFrameProcessor(Processor):
         self._fast_scanner_frequency = self._acq.hw.fast_raster_scanner.frequency
 
         # Pre-allocate array for processed image
-        self.processed = np.zeros(self.processed_shape, dtype=np.uint16)
+        if self._acq.data_acquisition_device.data_range.min < 0:
+            # If the data range min is negative, then we will need SIGNED integer data
+            self.processed = np.zeros(self.processed_shape, dtype=np.int16)
+        else:
+            self.processed = np.zeros(self.processed_shape, dtype=np.uint16)
 
         # Trigger timing
         self._fixed_trigger_delay = self._acq.hw.digitizer.acquire.trigger_delay_samples
         self._trigger_phase = 0 # This value can be adjusted
         if hasattr(self._acq.hw.fast_raster_scanner, 'input_delay'):
             self._trigger_phase = self._acq.hw.fast_raster_scanner.input_delay * self._spec.pixel_rate
+
+        self._scaling_factor = 2**(self._bits_precision - self._acq.data_acquisition_device.bit_depth)
         
     def run(self):
         # Calculate preliminary start indices
@@ -165,7 +190,7 @@ class RasterFrameProcessor(Processor):
                 return # concludes run() - this thread ends
 
             t0 = time.perf_counter()
-            resample_kernel(buf.data, self.processed, start_indices, nsamples_to_sum)
+            resample_kernel(buf.data, self._scaling_factor, self.processed, start_indices, nsamples_to_sum)
             
             self.publish(ProcessedFrame(
                 data=self.processed, 
@@ -259,6 +284,25 @@ class RasterFrameProcessor(Processor):
     
     @property
     def samples_per_period(self) -> float:
-        """The exact number of digitizer samples per fast raster scanner period.
+        """
+        The exact number of digitizer samples per fast raster scanner period.
         """
         return self._sample_clock_rate / self._fast_scanner_frequency 
+    
+    @property
+    def data_range(self):
+        """
+        The data range after processing (resampling) has been performed.
+
+        May be higher than the native bit depth of the data capture device.
+        """
+        if self._acq.data_acquisition_device.data_range.min < 0:
+            return units.ValueRange(
+                min=-2**(self._bits_precision-1), 
+                max=2**(self._bits_precision-1) - 1
+            )
+        else: # unsigned data
+            return units.ValueRange(
+                min=0, 
+                max=2**self._bits_precision - 1
+            )

--- a/dirigo/sw_interfaces/processor.py
+++ b/dirigo/sw_interfaces/processor.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
+from abc import abstractmethod
 
 import numpy as np
 
+from dirigo import units 
 from dirigo.sw_interfaces.worker import Worker
 from dirigo.sw_interfaces.acquisition import Acquisition
 
@@ -31,3 +33,12 @@ class Processor(Worker):
         self._acq = acquisition
         self._spec = acquisition.spec
     
+    @property
+    @abstractmethod # Not sure this is absolutely needed for every subclass of this.
+    def data_range(self) -> units.ValueRange:
+        """
+        The data range after processing (resampling) has been performed.
+
+        May be higher than the native bit depth of the data capture device.
+        """
+        pass

--- a/dirigo/units.py
+++ b/dirigo/units.py
@@ -3,6 +3,8 @@ import re
 from typing import Dict
 from dataclasses import dataclass
 
+import numpy as np
+
 
 class UnitQuantity(float):
     """
@@ -505,3 +507,36 @@ class ValueRange:
     @property
     def range(self) -> int:
         return self.max - self.min
+    
+    @property
+    def recommended_dtype(self):
+        """
+        Returns the recommended Numpy data type to store data of this range.
+        """
+        if self.min < 0:
+            # signed data types ...
+            if self.max < 2**7:
+                return np.int8
+            elif self.max < 2**15:
+                return np.int16
+            elif self.max < 2**31:
+                return np.int32
+            elif self.max < 2**63:
+                return np.int64
+            else:
+                return np.int128
+
+        else: 
+            # unsigned data types ..
+            if self.min == False and self.max == True:
+                return np.bool
+            elif self.max < 2**8:
+                return np.uint8
+            elif self.max < 2**16:
+                return np.uint16
+            elif self.max < 2**32:
+                return np.uint32
+            elif self.max < 2**64:
+                return np.uint64
+            else:
+                return np.uint128


### PR DESCRIPTION
Completed overhaul of data ranges. There are now 4 data ranges throughout the data lifespan (from acquisition buffer to presented image):

1) Acquisition range: meant to be close to the 'native' range provided by the acquisition hardware. For bipolar input ranges (e.g. +/2 V) this means signed integer data. For devices like cameras that have no notion of 'negative' values, then the data should be returned in unsigned integers. From now, the expectation is that the hardware plugin will provide data fulfilling this requirement and provide accurate methods for .bit_depth and .data_range properties. [see Note]

2) Processor range: will maintain signed/unsigned status of the acquired data, but by default will scale up (i.e. bit shift) the data to occupy the full 16 bits of data. This is used primarily when some processing, like averaging is done so as to maintain highest practical level of precision. The processor should also provide a data_range property for subscribers (Display) to use to anticipate incoming data range.

3) Blended range. The result of additive (or other strategies in future) blending of channels. This is done with a multichannel LUT of shape: [nchannels, nlevels, 3|4] (nchannels is physical channels) (3|4 is bits per pixel and depends on the GUI environment, Qt is 4 for BGRA, Tk is 3 for RGB).

4) Display range: result of passing blended range through a final gamma LUT. Should be data scaled properly for direct display on the user's monitor.

The Logger worker should save either 1 or 2 depending on needs/goals.


[Note] APIs (Alazar) will return data that doesn't follow this convention. It is the responsibility of the hardware plugin to convert. Example of this conversion: https://github.com/dirigo-developers/dirigo-alazar/commit/837b90a8ed65db799102eb7fa39fef115df59c26