### PR TITLE
Galvo-galvo analog scanning now acquires multiple samples per pixel period (numeric integration)

### DIFF
--- a/dirigo/hw_interfaces/digitizer.py
+++ b/dirigo/hw_interfaces/digitizer.py
@@ -567,6 +567,8 @@ class Digitizer(ABC):
         if "rate" in profile["sample_clock"]:
             # rate setter method should handle converting string representation into units.SampleRate
             self.sample_clock.rate = profile["sample_clock"]["rate"] 
+        else:
+            self.sample_clock.rate = None
         self.sample_clock.edge = profile["sample_clock"]["edge"]
 
         for i, channel in enumerate(self.channels):
@@ -585,7 +587,8 @@ class Digitizer(ABC):
             self.trigger.external_range = profile["trigger"]["external_range"]
         if "external_coupling" in profile["trigger"]:
             self.trigger.external_coupling = profile["trigger"]["external_coupling"]
-        self.trigger.source = profile["trigger"]["source"]
+        if "source" in profile["trigger"]:
+            self.trigger.source = profile["trigger"]["source"]
         self.trigger.slope = profile["trigger"]["slope"]
         if "level" in profile["trigger"]:
             self.trigger.level = 0

--- a/dirigo/hw_interfaces/digitizer.py
+++ b/dirigo/hw_interfaces/digitizer.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
+import math
 
 from platformdirs import user_config_dir
 
@@ -562,7 +563,7 @@ class Digitizer(ABC):
         profile_fn = profile_name + ".toml"
         profile = load_toml(self.PROFILE_LOCATION / profile_fn)
         
-        self.sample_clock.source = profile["sample_clock"]["clock_source"]
+        self.sample_clock.source = profile["sample_clock"]["source"]
         if "rate" in profile["sample_clock"]:
             # rate setter method should handle converting string representation into units.SampleRate
             self.sample_clock.rate = profile["sample_clock"]["rate"] 
@@ -591,12 +592,6 @@ class Digitizer(ABC):
 
     @property
     @abstractmethod
-    def bit_depth(self) -> int:
-        """Returns the bit depth (sample resolution) of the digitizer."""
-        pass
-
-    @property
-    @abstractmethod
     def data_range(self) -> units.ValueRange:
         """
         Returns the range of values returned by the digitizer 
@@ -605,3 +600,10 @@ class Digitizer(ABC):
         for in-place averaging.
         """
         pass
+
+    @property
+    def bit_depth(self) -> int:
+        """Returns the bit depth (sample resolution) of the digitizer.
+        
+        Requires data_range to be set up accurately in subclass."""
+        return math.ceil(math.log2(self.data_range.range))

--- a/dirigo/main.py
+++ b/dirigo/main.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
 
     processor.start()
     display.start()
-    logging.start()
+    #logging.start()
     acquisition.start()
 
     acquisition.join(timeout=100.0)

--- a/dirigo/plugins/acquisitions.py
+++ b/dirigo/plugins/acquisitions.py
@@ -362,7 +362,7 @@ class FrameAcquisition(LineAcquisition):
         self.hw.slow_raster_scanner.park()
         try:
             self.hw.fast_raster_scanner.park()
-        except NotImplemented:
+        except NotImplementedError:
             pass # Scanners like resonant scanners can't be parked.
         
         

--- a/dirigo/plugins/digitizers.py
+++ b/dirigo/plugins/digitizers.py
@@ -479,7 +479,7 @@ class NIAcquire(digitizer.Acquire):
 
     @property
     def record_length_resolution(self) -> int:
-        return 1
+        return 32
 
     @property
     def records_per_buffer(self) -> int:

--- a/dirigo/plugins/displays.py
+++ b/dirigo/plugins/displays.py
@@ -194,6 +194,28 @@ class FrameDisplay(Display):
             self._n_frame_average = n_frames
             self._average_buffer = None # Triggers reset of the average buffer 
 
+    @property
+    def gamma(self) -> float:
+        return self._gamma
+    
+    @gamma.setter
+    def gamma(self, new_gamma: float):
+        if not isinstance(new_gamma, float):
+            raise ValueError("Gamma must be set with a float value")
+        if not (0 < new_gamma <= 10):
+            raise ValueError("Gamma must be between 0.0 and 10.0")
+        self._gamma = new_gamma
+
+        # Generate gamma correction LUT
+        x = np.arange(self.gamma_lut_length) \
+            / (self.gamma_lut_length - 1) # TODO, not sure about the -1
+        
+        gamma_lut = (2**self._monitor_bit_depth - 1) * x**(self._gamma)
+        if self._monitor_bit_depth > 8:
+            self.gamma_lut = np.round(gamma_lut).astype(np.uint16)
+        else:
+            self.gamma_lut = np.round(gamma_lut).astype(np.uint8)
+
     def update_display(self, skip_when_acquisition_in_progress: bool = True):
         """
         On demand reprocessing of the last acquired frame for display.

--- a/dirigo/plugins/displays.py
+++ b/dirigo/plugins/displays.py
@@ -40,8 +40,9 @@ sigs = [
 def additive_display_kernel(data: np.ndarray, luts: np.ndarray, gamma_lut: np.ndarray) -> np.ndarray:
     """Applies LUTs and blends channels additively."""
     Ny, Nx, Nc = data.shape
-    _, transfer_function_max_index, bpp = luts.shape
-    
+    bpp = luts.shape[2]
+    gamma_lut_length = gamma_lut.shape[0]
+
     image = np.zeros(shape=(Ny, Nx, bpp), dtype=np.uint8)
 
     for yi in prange(Ny):
@@ -55,9 +56,9 @@ def additive_display_kernel(data: np.ndarray, luts: np.ndarray, gamma_lut: np.nd
                 b += luts[ci, lut_index, 2]
             
             # Gamma correct blended values and assign to output image 
-            image[yi, xi, 0] = gamma_lut[min(r, transfer_function_max_index)]
-            image[yi, xi, 1] = gamma_lut[min(g, transfer_function_max_index)]
-            image[yi, xi, 2] = gamma_lut[min(b, transfer_function_max_index)]
+            image[yi, xi, 0] = gamma_lut[min(r, gamma_lut_length-1)]
+            image[yi, xi, 1] = gamma_lut[min(g, gamma_lut_length-1)]
+            image[yi, xi, 2] = gamma_lut[min(b, gamma_lut_length-1)]
 
     return image
 

--- a/dirigo/plugins/processors.py
+++ b/dirigo/plugins/processors.py
@@ -176,7 +176,7 @@ class RasterFrameProcessor(Processor):
         self._fixed_trigger_delay = self._acq.hw.digitizer.acquire.trigger_delay_samples
         self._trigger_phase = 0 # This value can be adjusted
         if hasattr(self._acq.hw.fast_raster_scanner, 'input_delay'):
-            self._trigger_phase = self._acq.hw.fast_raster_scanner.input_delay * self._acq.hw.digitizer.sample_clock.rate
+            self._trigger_phase = self._acq.hw.fast_raster_scanner.input_delay * self._sample_clock_rate
 
         self._scaling_factor = 2**(self._bits_precision - self._acq.data_acquisition_device.bit_depth) # should we bit shift instead of scale with multiply?
 

--- a/dirigo/plugins/processors.py
+++ b/dirigo/plugins/processors.py
@@ -70,12 +70,12 @@ def resample_kernel(buffer_data: np.ndarray,
     return resampled
 
 
-
-@njit(
-    types.float32[:,:](types.uint16[:,:,:], types.int64, types.int64, types.float64), 
-    nogil=True, parallel=True, fastmath=True, cache=True
-)
-def window_bidi_data(data: np.ndarray, lines_per_frame: int, trigger_delay:int, samples_per_period: float):
+sigs = [
+    types.float32[:,:](types.uint16[:,:,:], types.int64, types.int64, types.float64),
+    types.float32[:,:](types.int16[:,:,:],  types.int64, types.int64, types.float64)
+]
+@njit(sigs, nogil=True, parallel=True, fastmath=True, cache=True)
+def crop_bidi_data(data: np.ndarray, lines_per_frame: int, trigger_delay:int, samples_per_period: float):
     """Select ranages and convert to float32.
 
     Note: operates on channel 0 only.
@@ -267,7 +267,7 @@ class RasterFrameProcessor(Processor):
         """Measure the apparent fast raster scanner trigger phase for bidirectional acquisitions."""
         UPSAMPLE = 8 # TODO move this somewhere else
         
-        data_window = window_bidi_data(data, self._spec.lines_per_frame, self._acq.hw.digitizer.acquire.trigger_delay_samples, self.samples_per_period) # todo preallocate data_window
+        data_window = crop_bidi_data(data, self._spec.lines_per_frame, self._acq.hw.digitizer.acquire.trigger_delay_samples, self.samples_per_period) # todo preallocate data_window
 
         F = fft.rfft(data_window, axis=1, workers=4)
         xps = compute_cross_power_spectrum(F)

--- a/dirigo/sw_interfaces/display.py
+++ b/dirigo/sw_interfaces/display.py
@@ -157,7 +157,7 @@ class Display(Worker):
                  acquisition: Acquisition = None, 
                  processor: Processor = None,
                  monitor_bit_depth: int = 8,
-                 gamma: float = 2.2):
+                 gamma: float = 1/2.2):
         """Instantiate with either an Acquisition or Processor"""
         super().__init__()
 
@@ -165,19 +165,7 @@ class Display(Worker):
             raise ValueError("Unsupported monitor bit depth")
         self._monitor_bit_depth = monitor_bit_depth
         
-        if not isinstance(gamma, (float, int)) or not (0.1 <= gamma <= 10):
-            raise ValueError("Display gamma out of range")
-        self._gamma = gamma
-
-        # Generate gamma correction LUT
-        x = np.arange(self.gamma_lut_length) \
-            / (self.gamma_lut_length - 1) # TODO, not sure about the -1
-        
-        gamma_lut = (2**self._monitor_bit_depth - 1) * x**(1/self._gamma)
-        if self._monitor_bit_depth > 8:
-            self.gamma_lut = np.round(gamma_lut).astype(np.uint16)
-        else:
-            self.gamma_lut = np.round(gamma_lut).astype(np.uint8)
+        self.gamma = gamma # gamma setter will validate this
 
         if (acquisition is not None) and (processor is not None):
             raise ValueError("Error creating Display worker: "

--- a/dirigo/units.py
+++ b/dirigo/units.py
@@ -506,7 +506,7 @@ class ValueRange:
 
     @property
     def range(self) -> int:
-        return self.max - self.min
+        return 1 + self.max - self.min
     
     @property
     def recommended_dtype(self):


### PR DESCRIPTION
The concept of a pixel only exists in software, meaning the digitizer acquires some stretch of data needed to cover an image line. Then the Processor resamples (averages) the required number of consecutive samples to form pixels. Usually this is N number of samples, but sometimes it may be N, N+1, N, N+1, etc, depending on the ratio of sample clock to pixel clock. This is pretty flexible--you can choose arbitrary pixel times, sub-pixel shifts to match up the forward and reverse lines (in bidirectional scanning, not yet implemented). But the downside is none of the hardware really 'knows' the pixel timing--so pixel clock export is removed.

Analog out signal (driving galvos) is synced with the AI sample clock by way of a clock frequency divider task. It shoots for about a 200 kHz AO rate or up to 32X division of the AI sample clock. So that means the max 10 MS/s clock gets divided down to 312.5 kHz for the AO sample rate. But if you chose let's say 1 MS/s AI, it will divide by 4 to get around 200 KHz AO.

For photon counting mode (more specifically, edge counting) we do not allow for multiple samples per pixel because the counter is performing hardware-based integration. Instead, the program uses AO's internally generated sample clock as the sample clock where 1 sample = 1 pixel. This is like how I originally wrote it before realizing it may be beneficial to oversample.