### PR TITLE
Profiling

### DIFF
--- a/dirigo/components/profiling.py
+++ b/dirigo/components/profiling.py
@@ -1,0 +1,128 @@
+import contextvars, time, math
+from dataclasses import dataclass
+from queue import SimpleQueue, Empty
+from threading import Thread, Event
+
+
+run_id_var     = contextvars.ContextVar("dirigo_run_id", default=None)
+group_var      = contextvars.ContextVar("dirigo_group",  default=None)
+plugin_var     = contextvars.ContextVar("dirigo_plugin", default=None)
+worker_var     = contextvars.ContextVar("dirigo_worker", default=None)  # optional human name
+
+
+@dataclass(frozen=True)
+class MetricEvent:
+    run_id: str | None
+    group:  str | None       # "acquisition" | "processor" | "logger" | ...
+    plugin: str | None       # entry point name, e.g., "raster_line"
+    worker: str | None       # thread name or friendly name
+    stage:  str              # e.g., "digitizer.get_completed"
+    wall_ns: int
+    cpu_ns:  int
+    n:       int = 1
+
+
+_metrics_queue = SimpleQueue()
+
+
+class _Timer:
+    __slots__ = ("stage", "t0w", "t0c")
+    def __init__(self, stage: str): 
+        self.stage = stage
+
+    def __enter__(self):
+        self.t0w = time.perf_counter_ns() # should these just be float seconds or is there a reason to do ns?
+        self.t0c = time.thread_time()
+        return self
+    
+    def __exit__(self, *_):
+        wall = time.perf_counter_ns() - self.t0w
+        cpu  = int((time.thread_time() - self.t0c) * 1e9)
+        _metrics_queue.put(MetricEvent(
+            run_id_var.get(), 
+            group_var.get(), 
+            plugin_var.get(), 
+            worker_var.get(),
+            self.stage, 
+            wall, 
+            cpu
+        ))
+
+
+def timer(stage: str):       # Worker code just does: with timer("publish"):
+    return _Timer(stage)
+
+
+def incr(stage: str, n: int = 1):
+    _metrics_queue.put(MetricEvent(
+        run_id_var.get(), 
+        group_var.get(), 
+        plugin_var.get(), 
+        worker_var.get(),
+        stage, 
+        0, 
+        0, 
+        n)
+    )
+
+
+class MetricsAggregator(Thread):
+    def __init__(self, interval_s: float = 2.0):
+        super().__init__(daemon=True)
+        self.stop_ev = Event()
+        self.interval_s = interval_s
+        self.counters = {}    # ((worker,stage),"count")->int
+        self.wall = {}        # (worker,stage)->{bucket:int}
+        self.cpu  = {}        # (worker,stage)->{bucket:int}
+
+    @staticmethod
+    def _bucket(ns: int) -> int:
+        return 0 if ns <= 0 else int(math.log2(ns))
+
+    def _bump(self, dct, key, bucket):
+        m = dct.setdefault(key, {})
+        m[bucket] = m.get(bucket, 0) + 1
+
+    def run(self):
+        last = time.time()
+        while not self.stop_ev.is_set():
+            try:
+                ev = _metrics_queue.get(timeout=0.1)
+                key = (ev.worker, ev.stage)
+                self.counters[(key,"count")] = self.counters.get((key,"count"),0) + ev.n
+                if ev.wall_ns: self._bump(self.wall, key, self._bucket(ev.wall_ns))
+                if ev.cpu_ns:  self._bump(self.cpu,  key, self._bucket(ev.cpu_ns))
+            except Empty:
+                pass
+            if time.time() - last >= self.interval_s:
+                self._emit_snapshot()
+                last = time.time()
+
+    def _emit_snapshot(self):
+        lines = []
+        keys = {k for (k, tag) in self.counters.keys() if tag == "count"}
+        for key in sorted(keys):
+            cnt = self.counters.get((key,"count"), 0)
+            p50w, p95w, p99w = self._percentiles(self.wall.get(key, {}))
+            p50c, p95c, p99c = self._percentiles(self.cpu.get(key,  {}))
+            worker, stage = key
+            lines.append(f"{worker}.{stage}: n={cnt} "
+                         f"wall p50/p95/p99={p50w}/{p95w}/{p99w} µs "
+                         f"cpu p50/p95/p99={p50c}/{p95c}/{p99c} µs")
+        if lines:
+            print("[metrics]", *lines, sep="\n")
+
+    @staticmethod
+    def _percentiles(hist):
+        if not hist: return (0,0,0)
+        total = sum(hist.values()); acc = 0
+        targets = [0.5*total, 0.95*total, 0.99*total]
+        out = []
+        for b in sorted(hist):
+            acc += hist[b]
+            while targets and acc >= targets[0]:
+                ns = (2**b + 2**(b+1))//2
+                out.append(int(ns/1000))  # µs
+                targets.pop(0)
+        while len(out)<3: out.append(out[-1] if out else 0)
+        return tuple(out)

--- a/dirigo/components/profiling.py
+++ b/dirigo/components/profiling.py
@@ -66,7 +66,7 @@ def incr(stage: str, n: int = 1):
     )
 
 
-class MetricsAggregator(Thread):
+class MetricsAggregator(Thread): # Should this be a dirigo.Worker?
     def __init__(self, interval_s: float = 2.0):
         super().__init__(daemon=True)
         self.stop_ev = Event()

--- a/dirigo/main.py
+++ b/dirigo/main.py
@@ -15,8 +15,7 @@ from dirigo.plugins.displays import FrameDisplay
 _Worker = Acquisition | Loader | Processor | Display | Logger
 
 
-class PluginError(RuntimeError):
-    """Raised when a Dirigo plugin cannot be located or instantiated."""
+class PluginError(RuntimeError): ...
 
 
 @lru_cache
@@ -29,20 +28,39 @@ def _load_entry_points(group: str) -> dict[str, type]:
 
 class Dirigo:
     """High-level facade for building Dirigo acquisition pipelines."""
+    _instance: Optional["Dirigo"] = None
+    _init_args: Optional[dict] = None
+
+    def __new__(cls, *a, **k):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
     def __init__(self, 
-                 system_config_path: Optional[Path] = None) -> None:
+                 system_config_path: Optional[Path | str] = None,
+                 *,
+                 start_services: bool = False):
         
-        if system_config_path is None:
-            system_config_path = io.config_path() / "system_config.toml"
+        cfg = Path(system_config_path or (io.config_path() / "system_config.toml"))
+        args = {"system_config_path": cfg, "start_services": bool(start_services)}
+        if getattr(self, "_initialized", False):
+            if self._init_args and self._init_args != args:
+                raise RuntimeError(
+                    "Dirigo is a singleton and was already created with "
+                    f"{self._init_args}. New args {args} are not allowed."
+                )
+            return
         
-        if not system_config_path.exists():
+        if not cfg.exists():
             raise FileNotFoundError(
-                f"Could not find system configuration file at {system_config_path}."
+                f"Could not find system configuration file at {cfg}."
             )
         
-        self.system_config = io.SystemConfig.from_toml(system_config_path)
+        self.system_config = io.SystemConfig.from_toml(cfg)
         self.hw = Hardware(self.system_config) 
+
+        self._init_args = args
+        self._initialized = True
 
     def available(self, group: str) -> set[str]:
         """Return available plugin names for a given group."""
@@ -81,34 +99,42 @@ class Dirigo:
         try:
             cls = plugins[name]
         except KeyError:
-            raise PluginError(f"No {group} plugin named '{name}'. "
-                              f"Available: {set(plugins)}")
+            raise PluginError(
+                f"No {group} plugin named '{name}'. Available: {set(plugins)}"
+            )
+        
+        if group not in ("acquisition", "loader", "display", "processor", "logger"):
+            raise PluginError(f"Unsupported plugin group '{group}'.")
 
         # special handling per group
         if group == "acquisition":
             spec = kw.pop("spec", None)
             if isinstance(spec, str) or spec is None:
                 spec = cls.get_specification(spec_name=spec or "default")
-            return cls(self.hw, self.system_config, spec, **kw)              # type: ignore[arg-type]
+            obj = cls(self.hw, self.system_config, spec, **kw)              # type: ignore[arg-type]
         
-        if group == "loader":
+        elif group == "loader":
             # For loaders, spec information should be availabe in saved file
             file_path = kw.pop("file_path")
-            return cls(file_path, **kw)
-        
-        upstream = kw.pop("upstream")
-        autostart = kw.pop("autostart", True)
-        autoconnect = kw.pop("autoconnect", True)
+            obj = cls(file_path, **kw)
 
-        if group in ("display", "processor", "logger"):
+        else:
+            upstream = kw.pop("upstream")
+            autostart = kw.pop("autostart", True)
+            autoconnect = kw.pop("autoconnect", True)
+
             obj = cls(upstream, **kw)
             if autoconnect:
                 upstream.add_subscriber(obj)
             if autostart:
                 obj.start()
-            return obj
+        
+        obj._dirigo_group = group
+        obj._dirigo_plugin = name
+        if hasattr(obj, "thread_name"):
+            setattr(obj, "_dirigo_worker", obj.thread_name)
 
-        raise PluginError(f"Unsupported plugin group '{group}'.")
+        return obj 
     
     def make_acquisition(self, name: str, **kw: Any) -> Acquisition:
         return self.make("acquisition", name, **kw)

--- a/dirigo/plugins/acquisitions.py
+++ b/dirigo/plugins/acquisitions.py
@@ -174,7 +174,7 @@ class SampleAcquisition(Acquisition):
         acq.buffers_per_acquisition = self.spec.buffers_per_acquisition
         acq.buffers_allocated = self.spec.buffers_allocated
 
-    def run(self):
+    def _work(self):
         # TODO, should start and stop digitizer, set `active` event
         # 1) configure digitizer
         raise NotImplementedError 
@@ -297,7 +297,7 @@ class LineCameraAcquisition(Acquisition):
     def _get_free_product(self) -> AcquisitionProduct:
         return super()._get_free_product() # type: ignore
 
-    def run(self):
+    def _work(self):
         # Set up acquisition buffer pool
         shape = self.hw.frame_grabber._buffers[0].buffer.shape # TODO add some sort of shape/dtype to API for framegrabber
         dtype = self.hw.frame_grabber._buffers[0].buffer.dtype
@@ -464,7 +464,7 @@ class LineAcquisition(SampleAcquisition):
         # Capture runtime info
         self.runtime_info = LineAcquisitionRuntimeInfo.from_acquisition(self)
 
-    def run(self):
+    def _work(self):
         digi = self.hw.digitizer # for brevity
 
         # Enable detectors
@@ -781,7 +781,7 @@ class FrameAcquisition(LineAcquisition):
             1 - spec.flyback_periods / spec.records_per_buffer
         )
 
-    def run(self):
+    def _work(self):
         self.hw.slow_raster_scanner.start(
             periods_per_frame=self.spec.records_per_buffer
         )
@@ -878,7 +878,7 @@ class StackAcquisition(Acquisition):
                          timeout: float | None = None) -> AcquisitionProduct:
         return super()._receive_product(block, timeout) # type: ignore
 
-    def run(self):
+    def _work(self):
         """
         For video-rate frame scanning (resonant or polygon scanners), there are
         3 ways to manage axial movement during a Z stack:
@@ -887,7 +887,7 @@ class StackAcquisition(Acquisition):
             2) Very fast step (likely w/ piezo) during frame slow axis flyback 
             3) Step during a sacrificial frame period
 
-        For galvo-galvo scanning, 
+        For galvo-galvo scanning, ... TODO
         """
         # Move to lower limit
         z_scanner = self.hw.objective_z_scanner

--- a/dirigo/plugins/acquisitions.py
+++ b/dirigo/plugins/acquisitions.py
@@ -786,7 +786,7 @@ class FrameAcquisition(LineAcquisition):
             periods_per_frame=self.spec.records_per_buffer
         )
 
-        super().run() # The hard work is done by super's run method
+        super()._work() # The hard work is done by super's run method
 
     def cleanup(self):
         """Extends LineAcquisition's cleanup method to stop both slow axis and fast"""

--- a/dirigo/plugins/calibrations.py
+++ b/dirigo/plugins/calibrations.py
@@ -62,7 +62,7 @@ class TriggerDelayCalibration(Acquisition):
         self.digitizer_profile = self._frame_acquisition.digitizer_profile
         self.runtime_info = self._frame_acquisition.runtime_info
 
-    def run(self):
+    def _work(self):
         try:
             for i, ampl in enumerate(self._amplitudes):
                 try:
@@ -110,7 +110,7 @@ class TriggerDelayCalibrationLogger(Logger):
     def _receive_product(self) -> Processor.Product:
         return super()._receive_product(self) # type: ignore
         
-    def run(self):
+    def _work(self):
         try:
             while True:
                 with self._receive_product() as product:
@@ -194,7 +194,7 @@ class StageTranslationCalibration(Acquisition):
             self._fast_stage = self.hw.stages.y
         self._original_position = self._fast_stage.position
 
-    def run(self):
+    def _work(self):
         try:
             self._frame_acquisition.start()
 
@@ -248,7 +248,7 @@ class LineDistortionCalibrationLogger(Logger):
         self.filepath = io.config_path() / "optics" / (self.basename + ".csv")
         self.data_filepath = io.data_path() / (self.basename + "_data.csv")
 
-    def run(self):
+    def _work(self):
         self._frames, self._positions = [], [] # collect measurement frames/pos
         try:
             while True:
@@ -397,7 +397,7 @@ class SignalOffsetCalibrationLogger(Logger):
         self.basename = "signal_offset"
         self.filepath = io.config_path() / "digitizer" / (self.basename + ".csv")
 
-    def run(self):
+    def _work(self):
         self._buffers = [] # collect measurement frames/pos
         try:
             while True:
@@ -444,7 +444,7 @@ class LineGradientCalibrationLogger(Logger):
 
         self._acq: FrameAcquisition
 
-    def run(self):
+    def _work(self):
         self._frames = [] # collect measurement frames/pos
         try:
             while True:
@@ -521,7 +521,7 @@ class LaserPulseFrequencyCalibration(SampleAcquisition):
             divider = self.DIVIDER
         )
 
-    def run(self):
+    def _work(self):
 
         self.hw.digitizer.acquire.start()
         time.sleep(1)

--- a/dirigo/plugins/displays.py
+++ b/dirigo/plugins/displays.py
@@ -364,7 +364,7 @@ class FrameDisplay(Display):
         )
         self._update_tf_lut()
 
-    def run(self):
+    def _work(self):
         try:
             while True:
                 with self._receive_product() as product:

--- a/dirigo/plugins/loaders.py
+++ b/dirigo/plugins/loaders.py
@@ -63,7 +63,7 @@ class RawRasterFrameLoader(Loader):
 
             self.frames_read = 0
 
-    def run(self):
+    def _work(self):
         try:
             with tifffile.TiffFile(self._file_path) as tif:   
                 

--- a/dirigo/plugins/loggers.py
+++ b/dirigo/plugins/loggers.py
@@ -90,7 +90,7 @@ class TiffLogger(Logger):
     def _receive_product(self) ->  AcquisitionProduct | ProcessorProduct:
         return super()._receive_product(self) # type: ignore
          
-    def run(self):
+    def _work(self):
         try:
             while True:
                 with self._receive_product() as product:

--- a/dirigo/plugins/processors.py
+++ b/dirigo/plugins/processors.py
@@ -232,7 +232,7 @@ class RasterFrameProcessor(Processor[Acquisition]):
     def _receive_product(self, block: bool = True, timeout: float | None = None) -> AcquisitionProduct:
         return super()._receive_product(block, timeout) # type: ignore
 
-    def run(self):
+    def _work(self):
         try:
             while True: 
 
@@ -450,7 +450,7 @@ class LineCameraLineProcessor(Processor[LineCameraLineAcquisition]):
             except EndOfStream:
                 break
     
-    def run(self):
+    def _work(self):
         try:
             for acq_prod in self._product_stream():
                 proc_product = self._get_free_product()
@@ -580,7 +580,7 @@ class RollingAverageProcessor(Processor[RasterFrameProcessor]):
                          ) -> AcquisitionProduct | ProcessorProduct:
         return super()._receive_product(block, timeout) # type: ignore
     
-    def run(self):
+    def _work(self):
         try:
             while True:
                 with self._receive_product() as in_product:

--- a/dirigo/plugins/processors.py
+++ b/dirigo/plugins/processors.py
@@ -6,8 +6,8 @@ from numpy.polynomial.polynomial import Polynomial
 from numba import njit, prange, uint8, int16, uint16, int32, int64, float32, complex64
 from scipy import fft
 
-from dirigo.components import units
-from dirigo.components import io
+from dirigo.components import units, io
+from dirigo.components.profiling import timer
 from dirigo.sw_interfaces.worker import EndOfStream
 from dirigo.sw_interfaces.processor import Processor, ProcessorProduct
 from dirigo.sw_interfaces.acquisition import Acquisition, AcquisitionProduct
@@ -235,55 +235,51 @@ class RasterFrameProcessor(Processor[Acquisition]):
     def _work(self):
         try:
             while True: 
-
-                with self._receive_product() as acq_prod:
-                    proc_product = self._get_free_product() # Check out a product from the pool
-                    # TODO, following could be factored out into a private method to improve clarity
-                    t0 = time.perf_counter()
-
-                    # If array of timestamps are assigned (default is None)
-                    if isinstance(acq_prod.timestamps, np.ndarray):
-                        # Estimate scanner frequency from timestamps
-                        avg_trig_period = np.mean(np.diff(acq_prod.timestamps))
-                        self._fast_scanner_frequency = 1 / avg_trig_period
-                        # print("FAST SCANNER FREQ", self._fast_scanner_frequency)
-
-                    # Measure phase from bidi data (in uni-directional, phase is not critical)
-                    if self._spec.bidirectional_scanning:
-                        p = self._frames_processed % len(self._phases)
-                        self._phases[p] = self.measure_phase(acq_prod.data)
-                        self._trigger_error = np.median(self._phases[~np.isnan(self._phases)])
-                        # print("BIDI PHASE", self._trigger_error)
-
-                    # Update resampling start indices--these can change a bit if the scanner frequency drifts
-                    start_indices = self.calculate_start_indices(self._trigger_error) - self._fixed_trigger_delay
-                    nsamples_to_sum = np.abs(np.diff(start_indices, axis=1))
-                    t1 = time.perf_counter()
-
-                    resample_kernel(
-                        raw_data=acq_prod.data, 
-                        invert_mask=self._invert_mask,
-                        offset=self.signal_offset,
-                        bit_shift=self._scaling_factor,
-                        gradient=self._gradient,
-                        resampled=proc_product.data,
-                        start_indices=start_indices, 
-                        nsamples_to_sum=nsamples_to_sum
-                    )
-                    proc_product.timestamps = acq_prod.timestamps
-                    proc_product.positions = acq_prod.positions
-                    proc_product.phase = TWO_PI * self._trigger_error \
-                        / (self._acquisition.digitizer_profile.sample_clock.rate * avg_trig_period)
-                    proc_product.frequency = float(self._fast_scanner_frequency)
-
-                    self._publish(proc_product) # sends off to Logger and/or Display workers
+                with self._receive_product() as acquisition_product:
+                    processed = self._process_frame(acquisition_product)
+                    self._publish(processed) # sends off to Logger and/or Display workers
                     self._frames_processed += 1
-                    t2 = time.perf_counter()
-
-                    #print(f"RECALC: {1000*(t1-t0):.03f} | FRAME {1000*(t2-t1):.03f} ")
 
         except EndOfStream:
             self._publish(None) # forward sentinel
+
+    def _process_frame(self, acq_product: AcquisitionProduct) -> ProcessorProduct:
+        processed = self._get_free_product() # Check out a product from the pool
+
+        # If array of timestamps are assigned (default is None)
+        if isinstance(acq_product.timestamps, np.ndarray):
+            # Estimate scanner frequency from timestamps
+            avg_trig_period = np.mean(np.diff(acq_product.timestamps))
+            self._fast_scanner_frequency = 1 / avg_trig_period
+
+        # Measure phase from bidi data (in uni-directional, phase is not critical)
+        if self._spec.bidirectional_scanning:
+            p = self._frames_processed % len(self._phases)
+            self._phases[p] = self.measure_phase(acq_product.data)
+            self._trigger_error = np.median(self._phases[~np.isnan(self._phases)])
+
+        # Update resampling start indices--these can change a bit if the scanner frequency drifts
+        start_indices = self.calculate_start_indices(self._trigger_error) - self._fixed_trigger_delay
+        nsamples_to_sum = np.abs(np.diff(start_indices, axis=1))
+
+        with timer("resample_kernel"):
+            resample_kernel(
+                raw_data=acq_product.data, 
+                invert_mask=self._invert_mask,
+                offset=self.signal_offset,
+                bit_shift=self._scaling_factor,
+                gradient=self._gradient,
+                resampled=processed.data,
+                start_indices=start_indices, 
+                nsamples_to_sum=nsamples_to_sum
+            )
+        processed.timestamps = acq_product.timestamps
+        processed.positions = acq_product.positions
+        processed.phase = TWO_PI * self._trigger_error \
+            / (self._acquisition.digitizer_profile.sample_clock.rate * avg_trig_period)
+        processed.frequency = float(self._fast_scanner_frequency)
+        
+        return processed
 
     @cached_property
     def _temporal_edges(self):

--- a/dirigo/plugins/scanners.py
+++ b/dirigo/plugins/scanners.py
@@ -386,7 +386,7 @@ class GalvoWaveformWriter(threading.Thread):
         waveforms = self.generate_waveforms()
         self._ao_writer.write_many_sample(waveforms)
 
-    def run(self):
+    def _work(self):
         while not self._stop_event.is_set():
             try:
                 waveforms = self.generate_waveforms()

--- a/dirigo/sw_interfaces/acquisition.py
+++ b/dirigo/sw_interfaces/acquisition.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Type, List, Optional
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+import uuid
 
 import numpy as np
 
@@ -62,8 +63,14 @@ class AcquisitionProduct(Product):
 class AcquisitionWorker(Worker):
     Product = AcquisitionProduct
 
+    def __init__(self, thread_name: str):
+        super().__init__(thread_name)
+        
+        # Set the run ID -- note that there could be a collision of 2 or more
+        # AcquisitionWorkers streams converge at a downstream Worker.
+        self._dirigo_run_id = str(uuid.uuid4())
+
     def _get_free_product(self) -> AcquisitionProduct:
-        # print("QSIZE", self._product_pool.qsize())
         return self._product_pool.get()
 
 
@@ -80,7 +87,7 @@ class Acquisition(AcquisitionWorker):
                  hw: "Hardware", 
                  system_config: SystemConfig, 
                  spec: AcquisitionSpec, 
-                 thread_name: str = "Acquisition"):
+                 thread_name: str = "acquisition"):
         super().__init__(thread_name)
         self.hw = hw
         self.system_config = system_config
@@ -150,10 +157,12 @@ class Loader(AcquisitionWorker):
     Loads and makes available saved data for post-hoc analyses. Mimics the 
     publishing behavior of Acquisition.
     """
-    def __init__(self, file_path: str | Path, thread_name: str = "Loader"):
+    def __init__(self, 
+                 file_path: str | Path, 
+                 thread_name: str = "loader"):
         super().__init__(thread_name)
 
         file_path = Path(file_path)
         if not file_path.exists():
-            raise FileExistsError(f"Could not find file: {file_path}")
+            raise FileNotFoundError(f"Could not find file: {file_path}")
         self._file_path = file_path

--- a/dirigo/sw_interfaces/processor.py
+++ b/dirigo/sw_interfaces/processor.py
@@ -59,8 +59,6 @@ class Processor(Generic[U_co], Worker):
 
     def _get_free_product(self) -> ProcessorProduct:
         """Gets an available ProcessorProduct from the product pool."""
-        if self.__class__.__name__ == "RasterFrameProcessor":
-            print(self.__class__.__name__, "QSIZE:", self._product_pool.qsize())
         return super()._get_free_product() # type: ignore
     
     # def _receive_product(self, block = True, timeout = None) -> AcquisitionProduct | ProcessorProduct:

--- a/dirigo/sw_interfaces/worker.py
+++ b/dirigo/sw_interfaces/worker.py
@@ -82,12 +82,21 @@ class Worker(threading.Thread, ABC):
         self._dirigo_plugin: Optional[str] = None   # entry point name, e.g. "raster_line"
         self._dirigo_run_id: Optional[str] = None   # set by acquisitions; others inherit
 
-    @abstractmethod
-    def run(self):      # all subclasses should call super().run() in their implementations
+    def run(self):
+        # Final: subclasses should NOT shadow this method
         run_id_var.set(self._dirigo_run_id) # type: ignore
         group_var.set(self._dirigo_group) # type: ignore 
         plugin_var.set(self._dirigo_plugin) # type: ignore
         worker_var.set(self.name)  # type: ignore
+        try:
+            self._work()  # subclasses implement this
+        finally:
+            # optional: flush metrics/logs
+            pass
+
+    @abstractmethod
+    def _work(self):
+        ...
     
     def _init_product_pool(self, 
                            n: int, 

--- a/dirigo/sw_interfaces/worker.py
+++ b/dirigo/sw_interfaces/worker.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
-import threading
-import queue
+import threading, queue
 from typing import Optional
 
 import numpy as np
+
+from dirigo.components.profiling import run_id_var, group_var, plugin_var, worker_var
+
 
 
 class EndOfStream(Exception):
@@ -55,7 +57,7 @@ class Product:
 class Worker(threading.Thread, ABC):
     Product = Product
 
-    def __init__(self, name: str = "Worker"):
+    def __init__(self, name: str = "worker"):
         """
         Sets up a worker Thread object with internal publisher-subscriber model.
 
@@ -73,10 +75,19 @@ class Worker(threading.Thread, ABC):
         # Pool for re-usable product objects
         self._product_pool = queue.Queue()
         self._product_shape: Optional[tuple[int, ...]] = None
+        self._product_dtype = None
+        
+        # Set context
+        self._dirigo_group: Optional[str] = None    # "acquisition"/"processor"/"logger"/"display"/"loader"
+        self._dirigo_plugin: Optional[str] = None   # entry point name, e.g. "raster_line"
+        self._dirigo_run_id: Optional[str] = None   # set by acquisitions; others inherit
 
     @abstractmethod
-    def run(self):
-        pass
+    def run(self):      # all subclasses should call super().run() in their implementations
+        run_id_var.set(self._dirigo_run_id) # type: ignore
+        group_var.set(self._dirigo_group) # type: ignore 
+        plugin_var.set(self._dirigo_plugin) # type: ignore
+        worker_var.set(self.name)  # type: ignore
     
     def _init_product_pool(self, 
                            n: int, 
@@ -114,8 +125,11 @@ class Worker(threading.Thread, ABC):
 
     # Publisher-Subscriber model
     def add_subscriber(self, subscriber: 'Worker'):
-        """Add a reference to a new subscriber."""
+        """Add a reference to a new subscriber and inherit run ID if applicable."""
         self._subscribers.append(subscriber)
+
+        if getattr(self, "_dirigo_run_id", None):
+            subscriber._dirigo_run_id = self._dirigo_run_id
 
     def remove_subscriber(self, subscriber: 'Worker'):
         """Remove reference to a subscriber."""


### PR DESCRIPTION
Added components to allow profiling of any step in the run-able part of an worker. Changed the name of the run-able part from run() [shadowing the default Thread method] to _work() which will be automatically wrapped with injected Worker context info. 