### PR TITLE
renamed Logger to Writer

### DIFF
--- a/dirigo/components/profiling.py
+++ b/dirigo/components/profiling.py
@@ -13,7 +13,7 @@ worker_var     = contextvars.ContextVar("dirigo_worker", default=None)  # option
 @dataclass(frozen=True)
 class MetricEvent:
     run_id: str | None
-    group:  str | None       # "acquisition" | "processor" | "logger" | ...
+    group:  str | None       # "acquisition" | "processor" | "writer" | ...
     plugin: str | None       # entry point name, e.g., "raster_line"
     worker: str | None       # thread name or friendly name
     stage:  str              # e.g., "digitizer.get_completed"

--- a/dirigo/main.py
+++ b/dirigo/main.py
@@ -8,7 +8,7 @@ from dirigo.components.hardware import Hardware
 from dirigo.sw_interfaces.display import DisplayPixelFormat
 
 if TYPE_CHECKING:
-    from dirigo.sw_interfaces import Acquisition, Processor, Display, Logger
+    from dirigo.sw_interfaces import Acquisition, Processor, Display, Writer
     from dirigo.sw_interfaces.acquisition import AcquisitionSpec, Loader
     from dirigo.plugins.processors import RollingAverageProcessor
     from dirigo.plugins.displays import FrameDisplay
@@ -85,13 +85,13 @@ class Dirigo:
              **kw: Any) -> "Display": ...
     
     @overload
-    def make(self, group: Literal["logger"], name: str, *,
-             upstream: "Acquisition | Processor", **kw: Any) -> "Logger": ...
+    def make(self, group: Literal["writer"], name: str, *,
+             upstream: "Acquisition | Processor", **kw: Any) -> "Writer": ...
 
     def make(self, group: str, name: str, **kw: Any
-             ) -> "Acquisition | Loader | Processor | Display | Logger":
+             ) -> "Acquisition | Loader | Processor | Display | Writer":
         """
-        Make pluggable pipeline elements (acquisitions, processors, loggers,
+        Make pluggable pipeline elements (acquisitions, processors, writers,
         displays)
         """
         plugins = _load_entry_points(group)
@@ -103,7 +103,7 @@ class Dirigo:
                 f"No {group} plugin named '{name}'. Available: {set(plugins)}"
             )
         
-        if group not in ("acquisition", "loader", "display", "processor", "logger"):
+        if group not in ("acquisition", "loader", "display", "processor", "writer"):
             raise PluginError(f"Unsupported plugin group '{group}'.")
 
         # special handling per group
@@ -160,5 +160,5 @@ class Dirigo:
     def make_display_processor(self, name: str, *, upstream, **kw: Any) -> "Display":
         return self.make("display", name, upstream=upstream, **kw)
     
-    def make_logger(self, name: str, *, upstream, **kw: Any) -> "Logger":
-        return self.make("logger", name, upstream=upstream, **kw)
+    def make_writer(self, name: str, *, upstream, **kw: Any) -> "Writer":
+        return self.make("writer", name, upstream=upstream, **kw)

--- a/dirigo/plugins/calibrations.py
+++ b/dirigo/plugins/calibrations.py
@@ -7,7 +7,7 @@ from scipy import fft
 
 from dirigo import units
 from dirigo import io
-from dirigo.sw_interfaces import Acquisition, Processor, Logger
+from dirigo.sw_interfaces import Acquisition, Processor, Writer
 from dirigo.sw_interfaces.worker import EndOfStream
 from dirigo.plugins.acquisitions import FrameAcquisition, SampleAcquisition
 from dirigo.plugins.processors import RasterFrameProcessor
@@ -98,7 +98,7 @@ class TriggerDelayCalibration(Acquisition):
             self._publish(None)
 
 
-class TriggerDelayCalibrationLogger(Logger):
+class TriggerDelayCalibrationWriter(Writer):
     """Logs measured trigger delay at amplitudes."""
     def __init__(self, upstream: Processor):
         super().__init__(upstream)
@@ -231,7 +231,7 @@ class StageTranslationCalibration(Acquisition):
             self._frame_acquisition.stop()
 
 
-class LineDistortionCalibrationLogger(Logger):
+class LineDistortionCalibrationWriter(Writer):
     """Logs apparent distortion use patches to create a local distortion field."""
     UPSAMPLE_X     = 20
     UPSAMPLE_Y     = 1
@@ -351,7 +351,7 @@ class LineDistortionCalibrationLogger(Logger):
         return i / cls.UPSAMPLE_Y, j / cls.UPSAMPLE_X
     
 
-class StageScannerAngleCalibrationLogger(LineDistortionCalibrationLogger):
+class StageScannerAngleCalibrationWriter(LineDistortionCalibrationWriter):
     UPSAMPLE_X     = 10
     UPSAMPLE_Y     = 10
 
@@ -360,7 +360,7 @@ class StageScannerAngleCalibrationLogger(LineDistortionCalibrationLogger):
         self.basename = "stage_scanner_angle"
         self.filepath = io.config_path() / "optics" / (self.basename + ".csv")
 
-    # run() is same as LineDistortionCalibrationLogger
+    # run() is same as LineDistortionCalibrationWriter
 
     def save_data(self):
         """Compare pairs of frames"""
@@ -390,7 +390,7 @@ class StageScannerAngleCalibrationLogger(LineDistortionCalibrationLogger):
         )
 
 
-class SignalOffsetCalibrationLogger(Logger):
+class SignalOffsetCalibrationWriter(Writer):
     
     def __init__(self, upstream: Processor):
         super().__init__(upstream)
@@ -434,7 +434,7 @@ class SignalOffsetCalibrationLogger(Logger):
         )
 
 
-class LineGradientCalibrationLogger(Logger):
+class LineGradientCalibrationWriter(Writer):
     
     def __init__(self, upstream: Processor):
         super().__init__(upstream)

--- a/dirigo/plugins/loaders.py
+++ b/dirigo/plugins/loaders.py
@@ -6,7 +6,7 @@ import tifffile
 import numpy as np
 
 from dirigo.sw_interfaces.acquisition import Loader
-from dirigo.plugins.loggers import TiffLogger
+from dirigo.plugins.writers import TiffWriter
 from dirigo.components.io import SystemConfig
 from dirigo.plugins.acquisitions import LineAcquisitionRuntimeInfo, FrameAcquisitionSpec
 from dirigo.hw_interfaces.digitizer import DigitizerProfile
@@ -49,16 +49,16 @@ class RawRasterFrameLoader(Loader):
 
             tags = tif.pages[0].tags
 
-            cfg_dict = json.loads(tags[TiffLogger.SYSTEM_CONFIG_TAG].value)
+            cfg_dict = json.loads(tags[TiffWriter.SYSTEM_CONFIG_TAG].value)
             self.system_config = SystemConfig(cfg_dict)
 
-            runtime_dict = json.loads(tags[TiffLogger.RUNTIME_INFO_TAG].value)
+            runtime_dict = json.loads(tags[TiffWriter.RUNTIME_INFO_TAG].value)
             self.runtime_info = LineAcquisitionRuntimeInfo.from_dict(runtime_dict)
 
-            spec_dict = json.loads(tags[TiffLogger.ACQUISITION_SPEC_TAG].value)
+            spec_dict = json.loads(tags[TiffWriter.ACQUISITION_SPEC_TAG].value)
             self.spec = spec_class(**spec_dict)
 
-            digi_dict = json.loads(tags[TiffLogger.DIGITIZER_PROFILE_TAG].value)
+            digi_dict = json.loads(tags[TiffWriter.DIGITIZER_PROFILE_TAG].value)
             self.digitizer_profile = DigitizerProfile.from_dict(digi_dict)
 
             self.frames_read = 0
@@ -70,10 +70,10 @@ class RawRasterFrameLoader(Loader):
                 n_frames = len(tif.pages)
                 
                 self._timestamps = deserialize_float64_list(
-                    tif.pages[0].tags[TiffLogger.TIMESTAMPS_TAG].value
+                    tif.pages[0].tags[TiffWriter.TIMESTAMPS_TAG].value
                 )
                 self._positions = deserialize_float64_list(
-                    tif.pages[0].tags[TiffLogger.POSITIONS_TAG].value
+                    tif.pages[0].tags[TiffWriter.POSITIONS_TAG].value
                 )
 
                 while self.frames_read < n_frames:

--- a/dirigo/plugins/processors.py
+++ b/dirigo/plugins/processors.py
@@ -253,7 +253,7 @@ class RasterFrameProcessor(Processor[Acquisition]):
             while True: 
                 with self._receive_product() as acquisition_product:
                     processed = self._process_frame(acquisition_product)
-                    self._publish(processed) # sends off to Logger and/or Display workers
+                    self._publish(processed) # sends off to Writer and/or Display workers
                     self._frames_processed += 1
 
         except EndOfStream:

--- a/dirigo/plugins/writers.py
+++ b/dirigo/plugins/writers.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from dirigo.sw_interfaces.worker import EndOfStream
 from dirigo.sw_interfaces.processor import Processor, ProcessorProduct
-from dirigo.sw_interfaces import Logger
+from dirigo.sw_interfaces import Writer
 from dirigo.sw_interfaces.acquisition import Acquisition, AcquisitionProduct
 from dirigo.plugins.acquisitions import (
     SampleAcquisitionSpec, FrameAcquisition, FrameAcquisitionSpec, 
@@ -49,7 +49,7 @@ def serialize_float64_list(arrays: Sequence[np.ndarray]) -> bytes:
     return header + stack.ravel().tobytes()
 
 
-class TiffLogger(Logger):
+class TiffWriter(Writer):
     """
     Saves image stream and metadata to tiff file.
 
@@ -117,7 +117,7 @@ class TiffLogger(Logger):
         elif self.mode == 'z-stack':
             self._store_z_plane(frame)
         else:
-            raise ValueError("Unsupported TiffLogger mode: {self.mode}")
+            raise ValueError("Unsupported TiffWriter mode: {self.mode}")
 
     def _save_frame(self, frame: AcquisitionProduct | ProcessorProduct):
         # Create the writer object if necessary

--- a/dirigo/sw_interfaces/__init__.py
+++ b/dirigo/sw_interfaces/__init__.py
@@ -1,6 +1,6 @@
 from .acquisition import Acquisition
 from .processor import Processor
 from .display import Display
-from .logger import Logger
+from .writer import Writer
 
-__all__ = ["Acquisition", "Processor", "Display", "Logger"]
+__all__ = ["Acquisition", "Processor", "Display", "Writer"]

--- a/dirigo/sw_interfaces/display.py
+++ b/dirigo/sw_interfaces/display.py
@@ -167,7 +167,7 @@ class Display(Worker):
         
         #self.gamma = gamma # gamma setter will validate this
 
-        if isinstance(upstream, (Processor, Display)): # TODO, refactor this into some sort of mixin (with Logger's corresponding block)
+        if isinstance(upstream, (Processor, Display)): # TODO, refactor this into some sort of mixin (with Writer's corresponding block)
             self._processor = upstream
             self._acquisition = upstream._acquisition
         elif isinstance(upstream, Acquisition):

--- a/dirigo/sw_interfaces/worker.py
+++ b/dirigo/sw_interfaces/worker.py
@@ -81,7 +81,7 @@ class Worker(threading.Thread, ABC):
         self._product_dtype = None # numpy dtype
         
         # Set context
-        self._dirigo_group: str | None = None    # "acquisition"/"processor"/"logger"/"display"/"loader"
+        self._dirigo_group: str | None = None    # "acquisition"/"processor"/"writer"/"display"/"loader"
         self._dirigo_plugin: str | None = None   # entry point name, e.g. "raster_line"
         self._dirigo_run_id: str | None = None   # set by acquisitions; others inherit
 

--- a/dirigo/sw_interfaces/writer.py
+++ b/dirigo/sw_interfaces/writer.py
@@ -11,14 +11,14 @@ from dirigo.sw_interfaces.processor import Processor, ProcessorProduct
 from dirigo.sw_interfaces.display import Display
 
 
-class Logger(Worker):
-    """Dirigo interface for data logging."""
+class Writer(Worker):
+    """Dirigo interface for data writing."""
     def __init__(self, 
                  upstream: Acquisition | Loader | Processor,
                  basename: str = "experiment",
                  ) -> None:
         """Instantiate with either an upstream Acquisition or Processor"""
-        super().__init__("Logger") # sets up the thread and the publisher-subcriber interface
+        super().__init__("Writer") # sets up the thread and the publisher-subcriber interface
         
         if isinstance(upstream, (Processor, Display)): 
             self._processor = upstream

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -7,7 +7,7 @@ and plugin discovery via entry points. Expand with diagrams as the design stabil
 flowchart LR
   A[Acquisition Worker] --> B[Processor Worker]
   B --> C[Display Worker]
-  B --> D[Logger Worker]
+  B --> D[Writer Worker]
   subgraph Hardware Plugins
     H1[Digitizer]:::hw
     H2[Stages]:::hw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dirigo"
-version = "0.3.1"
+version = "0.3.2"
 description = "Dirigo is a collection of interfaces for customizable image data acquisition"
 authors = [
     {name = "T. D. Weber", email = "tweber@mit.edu"}
@@ -52,14 +52,14 @@ inverted_gamma = "dirigo.plugins.displays:InvertedGamma"
 [project.entry-points."dirigo_displays"] # e.g. display processors
 frame = "dirigo.plugins.displays:FrameDisplay"
 
-[project.entry-points."dirigo_loggers"]
-tiff = "dirigo.plugins.loggers:TiffLogger"
-# special calibration loggers
-trigger_delay_calibration = "dirigo.plugins.calibrations:TriggerDelayCalibrationLogger"
-line_distortion_calibration = "dirigo.plugins.calibrations:LineDistortionCalibrationLogger"
-stage_scanner_angle_calibration = "dirigo.plugins.calibrations:StageScannerAngleCalibrationLogger"
-signal_offset_calibration = "dirigo.plugins.calibrations:SignalOffsetCalibrationLogger"
-line_gradient_calibration = "dirigo.plugins.calibrations:LineGradientCalibrationLogger"
+[project.entry-points."dirigo_writers"]
+tiff = "dirigo.plugins.writers:TiffWriter"
+# special calibration writers
+trigger_delay_calibration = "dirigo.plugins.calibrations:TriggerDelayCalibrationWriter"
+line_distortion_calibration = "dirigo.plugins.calibrations:LineDistortionCalibrationWriter"
+stage_scanner_angle_calibration = "dirigo.plugins.calibrations:StageScannerAngleCalibrationWriter"
+signal_offset_calibration = "dirigo.plugins.calibrations:SignalOffsetCalibrationWriter"
+line_gradient_calibration = "dirigo.plugins.calibrations:LineGradientCalibrationWriter"
 
 [project.entry-points."dirigo_encoders"]
 linear_encoders_via_ni = "dirigo.plugins.encoders:MultiAxisLinearEncodersViaNI"

--- a/scripts/calibrate_line_distortion.py
+++ b/scripts/calibrate_line_distortion.py
@@ -64,17 +64,17 @@ spec = StageTranslationCalibration.Spec(
 name = "line_distortion_calibration"
 acquisition = diri.make_acquisition("stage_translation_calibration", spec=spec)
 processor   = diri.make_processor("raster_frame", upstream=acquisition)
-logger      = diri.make_logger(name, upstream=processor)
+writer      = diri.make_writer(name, upstream=processor)
 # also log raw frame data so we can reprocess later to check calibration
-raw_logger  = diri.make("logger", "tiff", upstream=acquisition)
-raw_logger.basename = name
-raw_logger.frames_per_file = -1
+raw_writer  = diri.make("writer", "tiff", upstream=acquisition)
+raw_writer.basename = name
+raw_writer.frames_per_file = -1
 
 acquisition.start()
-logger.join()
+writer.join()
 
 # Check initial distortion
-check_calibration(logger.data_filepath, ff=spec.fill_fraction)
+check_calibration(writer.data_filepath, ff=spec.fill_fraction)
 
 
 # Check quality of correction using saved data and reprocessing frames
@@ -82,9 +82,9 @@ loader    = diri.make_loader("raw_raster_frame",
                       file_path=io.data_path() / f"{name}.tif",
                       spec_class=StageTranslationCalibration.Spec)
 processor = diri.make_processor("raster_frame", upstream=loader)
-logger    = diri.make_logger(name, upstream=processor)
+writer    = diri.make_writer(name, upstream=processor)
 
 loader.start()
-logger.join()
+writer.join()
 
-check_calibration(logger.data_filepath, ff=spec.fill_fraction)
+check_calibration(writer.data_filepath, ff=spec.fill_fraction)

--- a/scripts/calibrate_line_gradient.py
+++ b/scripts/calibrate_line_gradient.py
@@ -23,8 +23,8 @@ spec.pixel_height = spec.pixel_height / 100
 
 acquisition = diri.make("acquisition", "raster_frame", spec=spec)
 processor   = diri.make("processor", "raster_frame", upstream=acquisition)
-logger      = diri.make("logger", "line_gradient_calibration", upstream=processor)
+writer      = diri.make("writer", "line_gradient_calibration", upstream=processor)
 
 acquisition.start()
-logger.join()
+writer.join()
 

--- a/scripts/calibrate_signal_offsets.py
+++ b/scripts/calibrate_signal_offsets.py
@@ -10,8 +10,8 @@ axis parked (alterantively: keep shutter closed), so there is no real signal
 diri = Dirigo()
 
 acquisition = diri.make("acquisition", "raster_line")
-logger      = diri.make("logger", "signal_offset_calibration", upstream=acquisition)
+writer      = diri.make("writer", "signal_offset_calibration", upstream=acquisition)
 
 acquisition.start()
-logger.join()
+writer.join()
 

--- a/scripts/calibrate_stage_scanner_angle.py
+++ b/scripts/calibrate_stage_scanner_angle.py
@@ -22,8 +22,8 @@ spec = StageTranslationCalibration.Spec(
 
 acquisition = diri.make("acquisition", "stage_translation_calibration", spec=spec)
 processor   = diri.make("processor", "raster_frame", upstream=acquisition)
-logger      = diri.make("logger", "stage_scanner_angle_calibration", upstream=processor)
+writer      = diri.make("writer", "stage_scanner_angle_calibration", upstream=processor)
 
 acquisition.start()
-logger.join()
+writer.join()
 

--- a/scripts/calibrate_trigger_delay.py
+++ b/scripts/calibrate_trigger_delay.py
@@ -33,9 +33,9 @@ spec = TriggerDelayCalibration.Spec(
 name = "trigger_delay_calibration"
 acquisition = diri.make("acquisition", name, spec=spec)
 processor   = diri.make("processor", "raster_frame", upstream=acquisition)
-logger      = diri.make("logger", name, upstream=processor)
+writer      = diri.make("writer", name, upstream=processor)
 
 acquisition.start()
 
-# wait until logger finishes
-logger.join()
+# wait until writer finishes
+writer.join()

--- a/tests/raster_frame.py
+++ b/tests/raster_frame.py
@@ -8,7 +8,7 @@ diri = Dirigo()
 
 acquisition = diri.make_acquisition("raster_frame")
 if save_raw:
-    raw_logger = diri.make_logger("tiff", upstream=acquisition)
+    raw_writer = diri.make_writer("tiff", upstream=acquisition)
 processor = diri.make_processor("raster_frame", upstream=acquisition)
 averager = diri.make_processor("rolling_average", upstream=processor)
 display = diri.make_display_processor(
@@ -18,7 +18,7 @@ display = diri.make_display_processor(
     transfer_function_name  = "gamma"
 )
 if not save_raw:
-    logger = diri.make_logger("tiff", upstream=processor)
+    writer = diri.make_writer("tiff", upstream=processor)
 
 acquisition.start()
 acquisition.join(timeout=100.0)


### PR DESCRIPTION
The Worker responsible for saving data to disk was initially called a "Logger". But this naming conflicts with the conventional name for a periodic status helper (as is commonly used for debugging and performance profiling). Systematically changed Logger (and variants) to Writer. This naming is more consistent with this type of Worker's purpose.

Credit to @sploner for pushing me to make this change sooner rather than later.